### PR TITLE
Version 1.7.1 Quick Fix for libxml Error

### DIFF
--- a/inc/theme-functions.php
+++ b/inc/theme-functions.php
@@ -328,15 +328,16 @@ if ( ! function_exists( 'xsbf_footer_filter' ) ) :
 add_filter('xsbf_footer' , 'xsbf_footer_filter' , 10 , 1);
 function xsbf_footer_filter( $footer ) {
 
-	// Use PHP to parse the DOM structure and count the number of widgets
-	//ini_set ( 'display_errors', 1 ); //TEST
-	//$dom = new DOMDocument;
+	// Use PHP to parse the DOM structure and count the number of widgets. Note that we
+	// have to suppress errors because libxml doesn't recognize html5 tags yet. It still
+	// processes them just fine, though.
 	$dom = new DOMDocument('1.0', 'utf-8');
+	libxml_use_internal_errors(true);
 	$dom->loadHTML( $footer );
+	libxml_clear_errors();
+
 	$asides = $dom->getElementsByTagName('aside');
-	//echo '<pre>'; print_r( $asides); echo '</pre>'; //TEST
 	$num_widgets = $asides->length; 
-	//echo "num_widgets={$num_widgets}<br />"; //TEST
 
 	// Loop through each widget and modify the Bootstrap grid, depending on how many
 	foreach ($asides as $counter => $aside) {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: one-column, right-sidebar, left-sidebar, fluid-layout, responsive-layout, 
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=JGJUJVK99KHRE
 Requires at least: 4.2
 Tested up to: 4.4.2
-Stable tag: 1.7
+Stable tag: 1.7.1
 License: GPLv3
 License URI: http://www.opensource.org/licenses/GPL-3.0
 
@@ -350,6 +350,9 @@ For more information on SemVer, please visit [http://semver.org/].
 
 
 == CHANGELOG ==
+
+= 1.7.1 =
+* Quick fix to suppress an error message about libxml invalid tags when processing the site footer. This would only display when WordPress was in debug mode (like on a test site), but it was annoying anyway. If anyone cares, the "error" is really a warning that PHP's libxml doesn't yet understand HTML5 tags. It still processes them just fine, though.
 
 = 1.7 =
 * Increased the font size for the extra large icon ("icon-xlg") to 72px (was 50px). Reduced padding to 5px for that as well as the large icon ("icon-lg").

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://xtremelysocial.com/wordpress/flat/
 Author: XtremelySocial
 Author URI: http://xtremelysocial.com
 Description: Flat Bootstrap by XtremelySocial is a modern, fully responsive, "flat" style theme with a nice color palette, big full-width images, and full-width colored sections. It automatically adapts for desktops, tablets, and phones. It is based on the WordPress standard starter theme (_S) and the Twitter Bootstrap CSS framework. Features include a mobile navigation bar, multiple columns (grid), buttons, icons, labels, badges, tabbed content areas, collapsible content areas, progress bars, alert boxes, carousels (sliders) and much, much more. This is a theme for both users and theme developers with lots of features but without the bloat. For a live demo go to http://xtremelysocial.com/wordpress/flat/.
-Version: 1.7
+Version: 1.7.1
 License: GNU General Public License
 License URI: http://www.opensource.org/licenses/GPL-3.0
 Text Domain: flat-bootstrap


### PR DESCRIPTION
Quick fix to suppress an error message about libxml invalid tags when
processing the site footer. This would only display when WordPress was
in debug mode (like on a test site), but it was annoying anyway. If
anyone cares, the "error" is really a warning that PHP's libxml doesn't
yet understand HTML5 tags. It still processes them just fine, though.
